### PR TITLE
fix parse:properties to avoid duplicate index, as gov. records can be corrupted, when PAON or SAON is supplied as in different casing

### DIFF
--- a/src/parse:properties.js
+++ b/src/parse:properties.js
@@ -167,7 +167,7 @@ if (!file) {
             continue;
         }
 
-        obj.guid = `${obj.postcode}-${obj.street || ''}${obj.paon ? ` ${obj.paon}` : ''}${obj.saon ? `-${obj.saon}` : ''}`;
+        obj.guid = `${obj.postcode}-${obj.street || ''}${obj.paon ? ` ${obj.paon}` : ''}${obj.saon ? `-${obj.saon}` : ''}`.toUpperCase();
 
         transactions.push({
             guid: obj.guid,


### PR DESCRIPTION
fix most fresh data upload from (September 2022 batch)