### PR TITLE
use Set instead of Map for memory saving

### DIFF
--- a/src/parse:properties.js
+++ b/src/parse:properties.js
@@ -117,12 +117,12 @@ if (!file) {
     const properties = [];
     const transactions = [];
 
-    const propertiesGUIDMap = new Map();
+    const propertiesGUIDMap = new Set();
 
     await orm.Property.findAll({
         attributes: ['guid'],
         raw: true,
-    }).then((data) => data.forEach((v) => propertiesGUIDMap.set(v.guid)));
+    }).then((data) => data.forEach((v) => propertiesGUIDMap.add(v.guid)));
 
     let i = 0;
     let iter = 0;
@@ -178,7 +178,7 @@ if (!file) {
         });
 
         if (!propertiesGUIDMap.has(obj.guid)) {
-            propertiesGUIDMap.set(obj.guid);
+            propertiesGUIDMap.add(obj.guid);
 
             properties.push(obj);
         }


### PR DESCRIPTION
before (Map)

```
------------------------------------
FINAL BATCH
------------------------------------
>>> >> processed transactions: 27,547,855
>>> >> corrupted records: 44,577
>>> >> unique properties batch: 870
>>> >> unique properties: 15,037,043
memory: 1140.79 MB
------------------------------------
```

after (Set)
```
------------------------------------
FINAL BATCH
------------------------------------
>>> >> processed transactions: 27,547,855
>>> >> corrupted records: 44,577
>>> >> unique properties batch: 870
>>> >> unique properties: 15,037,043
memory: 1012.79 MB
------------------------------------

```